### PR TITLE
The version of UM that supports LOD2 is 530 and not 520.

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ Below is a list known softwares with full .EXT file support:
 
 - CrossWave 520
 - MYRIAD Model 520
-- Universal Model 520
+- Universal Model 530
 
 ## Licensing
 Copyright Orange 2020


### PR DESCRIPTION
In README.md, the version indicated for UM is not correct.