### PR TITLE
Moves the _La Defense_ sample description to a standalone README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,27 +35,16 @@ Please understand that pull requests will be reviewed by Orange and that some im
 
 ## Samples
 
-_La Grande Arche_ is an iconic building of the district of _La Défense_ in Paris, France.
-It is also the historical motivation for specifying a way to embed 3D models into GIS vector data.  
-The [sample](sample) folder of this repository contains the GIS vector files [la_defense.mif](sample/la_defense/la_defense.mif) and [la_defense.mid](sample/la_defense/la_defense.mid) of _La Grande Arche_.
-Together, they depict the building as a solid cube (figure 1 left), which height is read from the _height_ attribute in the [mid](sample/la_defense.mid) file.
+### [_La Grande Arche_](sample/la_defense/README.md)
 
-![](sample/la_defense/2.5dBuilding.png) ![](sample/la_defense/3dBuilding.png)  
-*Figure 1 — Legacy GIS cube model (left) of* La Grande Arche de la Défense *versus the .EXT enhanced model (right).*
+![](sample/la_defense/3dBuilding.png)  
 
-However, with the appropriate extrusion instructions (figure 2), the tesseract shape of the building can successfully be rendered (figure 1 right).
-The corresponding .EXT files are:
+### [_Halles des Vosges_](sample/halles_des_vosges/README.md)
 
-1. [back.ext](sample/la_defense/back.ext)
-2. [middle_square.ext](sample/la_defense/middle_square.ext)
-3. none (based on the _height_ attribute)
-4. [middle.ext](sample/la_defense/middle.ext)
-5. [front.ext](sample/la_defense/front.ext)
-
-![](sample/la_defense/assignments.svg)  
-*Figure 2 — Vectors from [la_defense.mif](sample/la_defense/la_defense.mif) (left) and their .EXT files assignements (right).*
+![](sample/halles_des_vosges/halles_back.png)
 
 ## Software Support
+
 Below is a list of known softwares with full .EXT file support:
 
 - CrossWave 520

--- a/README.md
+++ b/README.md
@@ -35,13 +35,13 @@ Please understand that pull requests will be reviewed by Orange and that some im
 
 ## Samples
 
-### [_La Grande Arche_](sample/la_defense/README.md)
-
 ![](sample/la_defense/3dBuilding.png)  
 
-### [_Halles des Vosges_](sample/halles_des_vosges/README.md)
+[_La Grande Arche_](sample/la_defense/README.md)
 
-![](sample/halles_des_vosges/halles_back.png)
+![](sample/halles_des_vosges/halles_back.png)  
+
+[_Halles des Vosges_](sample/halles_des_vosges/README.md)
 
 ## Software Support
 

--- a/sample/la_defense/README.md
+++ b/sample/la_defense/README.md
@@ -1,0 +1,19 @@
+_La Grande Arche_ is an iconic building of the district of _La Défense_ in Paris, France.
+It is also the historical motivation for specifying a way to embed 3D models into GIS vector data.  
+This directory contains the GIS vector files [la_defense.mif](la_defense.mif) and [la_defense.mid](la_defense.mid) of _La Grande Arche_.
+Together, they depict the building as a solid cube (figure 1 left), which height is read from the _height_ attribute in the [mid](la_defense.mid) file.
+
+![](2.5dBuilding.png) ![](3dBuilding.png)  
+*Figure 1 — Legacy GIS cube model (left) of* La Grande Arche de la Défense *versus the .EXT enhanced model (right).*
+
+However, with the appropriate extrusion instructions (figure 2), the tesseract shape of the building can successfully be rendered (figure 1 right).
+The corresponding .EXT files are:
+
+1. [back.ext](back.ext)
+2. [middle_square.ext](middle_square.ext)
+3. none (based on the _height_ attribute)
+4. [middle.ext](middle.ext)
+5. [front.ext](front.ext)
+
+![](assignments.svg)  
+*Figure 2 — Vectors from [la_defense.mif](la_defense.mif) (left) and their .EXT files assignements (right).*


### PR DESCRIPTION
Matching the structure of the _La Defense_ sample with the _Halles des Vosges_ sample.

The main README file now displays an index of the available samples.